### PR TITLE
Fixed improper casing on reference to Material UI textbox.

### DIFF
--- a/frontend/src/cms/components/authors/forms/SocialAccount/index.js
+++ b/frontend/src/cms/components/authors/forms/SocialAccount/index.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import TextField from 'material-ui/textField';
+import TextField from 'material-ui/TextField';
 
 const propTypes = {
   sortRank: PropTypes.number.isRequired,


### PR DESCRIPTION
Looks like you accidentally went camel case here rather than initial caps. This should prevent the cms portion from failing to compile.